### PR TITLE
Updated fabric.mod.json fields with additional information

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -8,9 +8,11 @@
     "Noxcrew"
   ],
   "contact": {
-    "repo": "https://github.com/Noxcrew/noxesium"
+    "repo": "https://github.com/Noxcrew/noxesium",
+    "homepage": "https://github.com/Noxcrew/noxesium",
+    "issues": "https://github.com/Noxcrew/noxesium/issues"
   },
-  "license": "",
+  "license": "GPL-3.0-only",
   "environment": "client",
   "entrypoints": {
     "client": [


### PR DESCRIPTION
This PR looks to add information about the license, alongside links to this repository, to the information included within the fabric.mod.json file, and by extension any mod menus or other services that utilise that information.