### PR TITLE
Add Github Action to automate creation of releases.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,9 +36,8 @@ jobs:
       
       - name: Setup Gradle Build
         uses: gradle/gradle-build-action@v2.2.2
-        
-      - name: Execute Gradle build
-        run: ./gradlew build
+        with:
+          arguments: build
         
       - name: Create Draft Release
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,51 @@
+# This is a basic workflow to help you get started with Actions
+
+name: Build Releases
+
+# Controls when the workflow will run
+on:
+  push:
+    tags:
+      - "v*.*.*"
+      
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v3
+      
+      - name: Setup Java JDK
+        uses: actions/setup-java@v3.4.1
+        with:
+          # The Java version to set up. Takes a whole or semver Java version. See examples of supported syntax in README file
+          java-version: 17
+          # Java distribution. See the list of supported distributions in README file
+          distribution: temurin
+      
+      - name: Gradle Build
+        # You may pin to the exact commit or the version.
+        # uses: gradle/gradle-build-action@cd3cedc781988c804f626f4cd2dc51d0bdf02a12
+        uses: gradle/gradle-build-action@v2.2.2
+        
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: build/libs/noxesium-[0-9]+.[0-9]+.[0-9]+.jar
+          draft: true
+        
+      
+    
+        
+      
+
+
+     

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,13 +30,17 @@ jobs:
           java-version: 17
           # Java distribution. See the list of supported distributions in README file
           distribution: temurin
+          
+      - name: Gradle Wrapper Validation
+        uses: gradle/wrapper-validation-action@v1.0.4
       
-      - name: Gradle Build
-        # You may pin to the exact commit or the version.
-        # uses: gradle/gradle-build-action@cd3cedc781988c804f626f4cd2dc51d0bdf02a12
+      - name: Setup Gradle Build
         uses: gradle/gradle-build-action@v2.2.2
         
-      - name: Release
+      - name: Execute Gradle build
+        run: ./gradlew build
+        
+      - name: Create Draft Release
         uses: softprops/action-gh-release@v1
         with:
           files: build/libs/noxesium-[0-9]+.[0-9]+.[0-9]+.jar

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,3 @@
-# This is a basic workflow to help you get started with Actions
-
 name: Build Releases
 
 # Controls when the workflow will run
@@ -42,7 +40,7 @@ jobs:
       - name: Create Draft Release
         uses: softprops/action-gh-release@v1
         with:
-          files: build/libs/noxesium-[0-9]+.[0-9]+.[0-9]+.jar
+          files: build/libs/noxesium-+([0-9]).+([0-9]).+([0-9]).jar
           draft: true
         
       

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,7 @@ name: Build Releases
 on:
   push:
     tags:
-      - "v*.*.*"
+      - "v[0-9]+.[0-9]+.[0-9]+ "
       
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -42,11 +42,3 @@ jobs:
         with:
           files: build/libs/noxesium-+([0-9]).+([0-9]).+([0-9]).jar
           draft: true
-        
-      
-    
-        
-      
-
-
-     

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,7 @@ name: Build Releases
 on:
   push:
     tags:
-      - "v[0-9]+.[0-9]+.[0-9]+"
+      - "v[0-9]+.[0-9]+.[0-9a-zA-Z]+"
       
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,7 @@ name: Build Releases
 on:
   push:
     tags:
-      - "v[0-9]+.[0-9]+.[0-9]+ "
+      - "v[0-9]+.[0-9]+.[0-9]+"
       
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -40,5 +40,5 @@ jobs:
       - name: Create Draft Release
         uses: softprops/action-gh-release@v1
         with:
-          files: build/libs/noxesium-+([0-9]).+([0-9]).+([0-9]).jar
+          files: build/libs/noxesium-+([0-9]).+([0-9]).+([0-9a-zA-Z]).jar
           draft: true


### PR DESCRIPTION
This PR looks to suggest / add a Github Action which, when a tag in the format vX.Y.Z is pushed, with X, Y and Z being integers, build the mod and create a draft release including a built copy of the mod, which can then be modified to include any relevant patch notes and subsequently released, rather than having to manually build and include a copy.