### PR TITLE
Raise HUD held item name to avoid overlapping faction icons in lobbies

### DIFF
--- a/src/main/java/com/noxcrew/noxesium/mixin/client/GuiMixin.java
+++ b/src/main/java/com/noxcrew/noxesium/mixin/client/GuiMixin.java
@@ -1,5 +1,6 @@
 package com.noxcrew.noxesium.mixin.client;
 
+import com.noxcrew.noxesium.rule.ServerRules;
 import net.minecraft.client.gui.Gui;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.Constant;
@@ -12,13 +13,11 @@ import org.spongepowered.asm.mixin.injection.ModifyConstant;
 @Mixin(Gui.class)
 public class GuiMixin {
 
-    private static final int ADJUST_BY = 5;
-
     @ModifyConstant(
             method = "renderSelectedItemName(Lcom/mojang/blaze3d/vertex/PoseStack;)V",
             constant = @Constant(intValue = 59)
     )
     public int modify(int constant) {
-        return constant + ADJUST_BY;
+        return constant + ServerRules.HELD_ITEM_NAME_OFFSET.get();
     }
 }

--- a/src/main/java/com/noxcrew/noxesium/mixin/client/GuiMixin.java
+++ b/src/main/java/com/noxcrew/noxesium/mixin/client/GuiMixin.java
@@ -1,0 +1,24 @@
+package com.noxcrew.noxesium.mixin.client;
+
+import net.minecraft.client.gui.Gui;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
+
+/**
+ * Raises the height of the held item name in the HUD to avoid
+ * faction icons overlapping.
+ */
+@Mixin(Gui.class)
+public class GuiMixin {
+
+    private static final int ADJUST_BY = 5;
+
+    @ModifyConstant(
+            method = "renderSelectedItemName(Lcom/mojang/blaze3d/vertex/PoseStack;)V",
+            constant = @Constant(intValue = 59)
+    )
+    public int modify(int constant) {
+        return constant + ADJUST_BY;
+    }
+}

--- a/src/main/java/com/noxcrew/noxesium/rule/IntegerServerRule.java
+++ b/src/main/java/com/noxcrew/noxesium/rule/IntegerServerRule.java
@@ -1,0 +1,26 @@
+package com.noxcrew.noxesium.rule;
+
+import net.minecraft.network.FriendlyByteBuf;
+
+/**
+ * A standard server rule that stores an integer.
+ */
+public class IntegerServerRule extends ServerRule<Integer> {
+
+    private final int defaultValue;
+
+    public IntegerServerRule(int index, int defaultValue) {
+        super(index);
+        this.defaultValue = defaultValue;
+    }
+
+    @Override
+    public Integer getDefault() {
+        return defaultValue;
+    }
+
+    @Override
+    public Integer read(FriendlyByteBuf buffer) {
+        return buffer.readVarInt();
+    }
+}

--- a/src/main/java/com/noxcrew/noxesium/rule/ServerRules.java
+++ b/src/main/java/com/noxcrew/noxesium/rule/ServerRules.java
@@ -21,4 +21,10 @@ public class ServerRules {
      * allowing the server to define which blocks are breakable globally regardless of tool.
      */
     public static ServerRule<CustomAdventureModeCheck> GLOBAL_CAN_DESTROY = new AdventureModeCheckServerRule(2);
+
+    /**
+     * An integer pixel amount to vertically offset the HUD held item name.
+     * useful for avoiding overlapping faction icons. Positive values move the text up.
+     */
+    public static ServerRule<Integer> HELD_ITEM_NAME_OFFSET = new IntegerServerRule(3, 0);
 }

--- a/src/main/resources/noxesium.mixins.json
+++ b/src/main/resources/noxesium.mixins.json
@@ -11,6 +11,7 @@
   "client": [
     "client.BlockStateBaseMixin",
     "client.ClientPacketListenerMixin",
+    "client.GuiMixin",
     "client.LivingEntityMixin",
     "client.MinecraftMixin",
     "client.ModelBakeryMixin",


### PR DESCRIPTION
Before:
<img width="445" src="https://user-images.githubusercontent.com/35287819/217945319-aba37d4d-d0a9-430d-b14c-6d988fb91bbb.png">

After:
<img width="445" src="https://user-images.githubusercontent.com/35287819/217945404-a1510556-1223-4e81-a222-fa6d98197392.png">

It's worth pointing out that this does slightly raise the height of the text all the time. Whether this is an issue is debatable, it's only a very minor difference.

<img width="445" src="https://user-images.githubusercontent.com/35287819/217945636-4224ac71-56f3-455f-964f-b642888b6247.png">
Vanilla for comparison:
<img width="483" alt="image" src="https://user-images.githubusercontent.com/35287819/217946400-d2e0ebf6-26e0-4b77-a1be-8291ce6d52bc.png">

