### PR TITLE
feature: Adding immovable items

### DIFF
--- a/src/main/java/com/noxcrew/noxesium/NoxesiumMod.java
+++ b/src/main/java/com/noxcrew/noxesium/NoxesiumMod.java
@@ -25,6 +25,9 @@ public class NoxesiumMod implements ClientModInitializer {
     public static final ResourceLocation CLIENT_SETTINGS_CHANNEL = new ResourceLocation("noxesium", "client_settings");
     public static final ResourceLocation SERVER_RULE_CHANNEL = new ResourceLocation("noxesium", "server_rules");
 
+    public static final String BUKKIT_COMPOUND_ID = "PublicBukkitValues";
+    public static final String IMMOVABLE_TAG = "mcc:immovable";
+
     @Override
     public void onInitializeClient() {
         ClientTickEvents.END_CLIENT_TICK.register((ignored1) -> {

--- a/src/main/java/com/noxcrew/noxesium/mixin/client/InventoryMixin.java
+++ b/src/main/java/com/noxcrew/noxesium/mixin/client/InventoryMixin.java
@@ -1,0 +1,41 @@
+package com.noxcrew.noxesium.mixin.client;
+
+import com.noxcrew.noxesium.NoxesiumMod;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.world.entity.player.Inventory;
+import net.minecraft.world.item.ItemStack;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
+
+import static com.noxcrew.noxesium.NoxesiumMod.BUKKIT_COMPOUND_ID;
+import static com.noxcrew.noxesium.NoxesiumMod.IMMOVABLE_TAG;
+
+/**
+ * Mixin for preventing items dropped from the Hotbar.
+ * This only prevent items with the {@link NoxesiumMod#IMMOVABLE_TAG} from being moved.
+ */
+@Mixin(Inventory.class)
+public abstract class InventoryMixin {
+
+    @Inject(
+            method = "removeFromSelected",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/world/item/ItemStack;isEmpty()Z"
+            ),
+            locals = LocalCapture.CAPTURE_FAILHARD,
+            cancellable = true
+    )
+    public void removeFromSelected(final boolean bl, final CallbackInfoReturnable<ItemStack> cir, final ItemStack itemStack) {
+        final CompoundTag tag = itemStack.getTag();
+        if (tag == null) return;
+
+        final CompoundTag bukkit = tag.getCompound(BUKKIT_COMPOUND_ID);
+        if (!bukkit.contains(IMMOVABLE_TAG)) return;
+
+        cir.setReturnValue(ItemStack.EMPTY);
+    }
+}

--- a/src/main/java/com/noxcrew/noxesium/mixin/client/InventorySlotMixin.java
+++ b/src/main/java/com/noxcrew/noxesium/mixin/client/InventorySlotMixin.java
@@ -1,0 +1,42 @@
+package com.noxcrew.noxesium.mixin.client;
+
+import com.noxcrew.noxesium.NoxesiumMod;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.protocol.game.ServerboundResourcePackPacket;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.inventory.Slot;
+import net.minecraft.world.item.ItemStack;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import static com.noxcrew.noxesium.NoxesiumMod.BUKKIT_COMPOUND_ID;
+import static com.noxcrew.noxesium.NoxesiumMod.IMMOVABLE_TAG;
+
+/**
+ * Mixin for preventing items from being moved inside custom inventories.
+ * This only prevent items with the {@link NoxesiumMod#IMMOVABLE_TAG} from being moved.
+ * This is done to improve using menus, as there won't be any flickering when clicking on buttons anymore.
+ */
+@Mixin(Slot.class)
+public abstract class InventorySlotMixin {
+
+    @Shadow
+    public abstract ItemStack getItem();
+
+    @Inject(method = "mayPickup", at = @At(value = "HEAD"), cancellable = true)
+    public void mayPickup(final Player player, final CallbackInfoReturnable<Boolean> cir) {
+        final ItemStack itemStack = getItem();
+        if (itemStack == null) return;
+
+        final CompoundTag tag = itemStack.getTag();
+        if (tag == null) return;
+
+        final CompoundTag bukkit = tag.getCompound(BUKKIT_COMPOUND_ID);
+        if (!bukkit.contains(IMMOVABLE_TAG)) return;
+
+        cir.setReturnValue(false);
+    }
+}

--- a/src/main/resources/noxesium.mixins.json
+++ b/src/main/resources/noxesium.mixins.json
@@ -5,6 +5,8 @@
   "compatibilityLevel": "JAVA_17",
   "plugin": "com.noxcrew.noxesium.NoxesiumMixinPlugin",
   "mixins": [
+    "client.InventorySlotMixin",
+    "client.InventoryMixin",
     "client.component.SkullBlockEntityExt",
     "client.entity.LivingEntityMixin"
   ],


### PR DESCRIPTION
Adds a check for a custom NBT "mcc:immovable" that we can add to items and prevent the client from moving them.
Using PDC as it's easier but we could also just add a custom tag instead.
Immovable items can't be dropped either, so even hot bar items will stay in place when pressing the drop button.
This really helps improve the smoothness of menus.