### PR TITLE
Disable boat collision with new server rule.

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,3 +170,10 @@ individual rule and how it interprets the incoming packet.
 |------------|------------|---------------------|
 | Index      | VarInt     | 5                   |
 | Enabled    | Boolean    | `false` by default. |
+
+**Disable Boat Collisions**. Disables boats colliding with other entities. Similar modification is recommended on the server side to ensure behaviour congruity.
+
+| Field Name | Field Type | Notes               |
+|------------|------------|---------------------|
+| Index      | VarInt     | 6                   |
+| Value      | Boolean    | `false` by default. |

--- a/api/src/main/java/com/noxcrew/noxesium/api/protocol/NoxesiumFeature.java
+++ b/api/src/main/java/com/noxcrew/noxesium/api/protocol/NoxesiumFeature.java
@@ -28,6 +28,10 @@ public enum NoxesiumFeature {
      */
     MUSIC_SERVER_RULE(3),
     /**
+     * Adds support for disabling boat on entity collisions.
+     */
+    BOAT_COLLISIONS_RULE(4),
+    /**
      * Supports the V1 API of Noxesium.
      */
     API_V1(3),

--- a/api/src/main/java/com/noxcrew/noxesium/api/protocol/rule/ServerRuleIndices.java
+++ b/api/src/main/java/com/noxcrew/noxesium/api/protocol/rule/ServerRuleIndices.java
@@ -36,4 +36,9 @@ public class ServerRuleIndices {
      * by clients and used by the server.
      */
     public static final int ENABLE_CUSTOM_MUSIC = 5;
+
+    /**
+     * Allows server to prevent boat on entity collisions on the client side.
+     */
+    public static final int DISABLE_BOAT_COLLISIONS = 6;
 }

--- a/fabric/src/main/java/com/noxcrew/noxesium/NoxesiumMod.java
+++ b/fabric/src/main/java/com/noxcrew/noxesium/NoxesiumMod.java
@@ -25,7 +25,7 @@ public class NoxesiumMod implements ClientModInitializer {
      * of Noxesium is available on the client. The protocol version will increment every full release, as such
      * ít is recommended to work with >= comparisons.
      */
-    public static final int VERSION = 3;
+    public static final int VERSION = 4;
 
     public static final String BUKKIT_COMPOUND_ID = "PublicBukkitValues";
     public static final String NAMESPACE = "noxesium";

--- a/fabric/src/main/java/com/noxcrew/noxesium/feature/rule/ServerRules.java
+++ b/fabric/src/main/java/com/noxcrew/noxesium/feature/rule/ServerRules.java
@@ -47,4 +47,11 @@ public class ServerRules {
      * own music.
      */
     public static ClientServerRule<Boolean> ENABLE_CUSTOM_MUSIC = new EnableMusicRule(ServerRuleIndices.ENABLE_CUSTOM_MUSIC);
+
+    /**
+     * When true, disables boat collision on the client side, useful for movement games involving
+     * boats and other entities in one area. Similar mechanism must exist server side to prevent lagbacks with this enabled.
+     */
+    public static ClientServerRule<Boolean> DISABLE_BOAT_COLLISIONS = new BooleanServerRule(ServerRuleIndices.DISABLE_BOAT_COLLISIONS, false);
+
 }

--- a/fabric/src/main/java/com/noxcrew/noxesium/mixin/entity/BoatMixin.java
+++ b/fabric/src/main/java/com/noxcrew/noxesium/mixin/entity/BoatMixin.java
@@ -1,0 +1,21 @@
+package com.noxcrew.noxesium.mixin.entity;
+
+import com.noxcrew.noxesium.feature.rule.ServerRules;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.vehicle.Boat;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(Boat.class)
+public class BoatMixin {
+
+    @Inject(method = "canCollideWith", at = @At(value = "HEAD"), cancellable = true)
+    public void injected(Entity entity, CallbackInfoReturnable<Boolean> ci) {
+        if (ServerRules.DISABLE_BOAT_COLLISIONS.getValue()) {
+            ci.setReturnValue(false);
+        }
+    }
+
+}

--- a/fabric/src/main/resources/noxesium.mixins.json
+++ b/fabric/src/main/resources/noxesium.mixins.json
@@ -23,6 +23,7 @@
     "component.SkinManagerExt",
     "component.SkullBlockEntityExt",
     "component.TextureCacheExt",
+    "entity.BoatMixin",
     "entity.LevelRendererMixin",
     "entity.TextDisplayRenderer",
     "info.MinecraftMixin",


### PR DESCRIPTION
Adds a new server rule with index 6 to disable boats colliding with other entities client side. Helpful in similar situations to the trident collision server rule., where the default behaviour would allow other entities to block the way.

Could help alleviate situations like [this](https://youtube.com/clip/Ugkx0QlMyN3UnM5-e6MwWQSGIfTa_m8FsihY?si=zNBrH8cXGmA_ZBrS) in similar game styles.

Main caveat for this system is as this behaviour exists both on client and server side, the server end would also need its own modifications to maintain congruity in the behaviour to prevent lackback issues.