### PR TITLE
Replace @Redirects that call the target with equivalent wraps

### DIFF
--- a/fabric/src/main/java/com/noxcrew/noxesium/mixin/general/LocalPlayerMixin.java
+++ b/fabric/src/main/java/com/noxcrew/noxesium/mixin/general/LocalPlayerMixin.java
@@ -1,22 +1,20 @@
 package com.noxcrew.noxesium.mixin.general;
 
+import com.llamalad7.mixinextras.injector.v2.WrapWithCondition;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.noxcrew.noxesium.NoxesiumMod;
-import net.minecraft.client.KeyMapping;
 import net.minecraft.client.player.LocalPlayer;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Redirect;
 
 /**
  * Makes resetting of toggle keys on respawn configurable in the accessibility settings.
  */
 @Mixin(LocalPlayer.class)
-public class LocalPlayerMixin {
+public abstract class LocalPlayerMixin {
 
-    @Redirect(method = "respawn", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/KeyMapping;resetToggleKeys()V"))
-    public void onResetToggleKeys() {
-        if (NoxesiumMod.getInstance().getConfig().resetToggleKeys) {
-            KeyMapping.resetToggleKeys();
-        }
+    @WrapWithCondition(method = "respawn", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/KeyMapping;resetToggleKeys()V"))
+    public boolean onResetToggleKeys() {
+        return NoxesiumMod.getInstance().getConfig().resetToggleKeys;
     }
 }

--- a/fabric/src/main/java/com/noxcrew/noxesium/mixin/rules/ItemInHandLayerMixin.java
+++ b/fabric/src/main/java/com/noxcrew/noxesium/mixin/rules/ItemInHandLayerMixin.java
@@ -1,5 +1,7 @@
 package com.noxcrew.noxesium.mixin.rules;
 
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.noxcrew.noxesium.feature.rule.InventoryHelper;
 import net.minecraft.client.renderer.entity.layers.ItemInHandLayer;
 import net.minecraft.world.entity.LivingEntity;
@@ -13,14 +15,14 @@ import org.spongepowered.asm.mixin.injection.Redirect;
  * Overrides the item shown as being held in the main hand on the 3d player model.
  */
 @Mixin(ItemInHandLayer.class)
-public class ItemInHandLayerMixin {
+public abstract class ItemInHandLayerMixin {
 
-    @Redirect(method = "render(Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;ILnet/minecraft/world/entity/LivingEntity;FFFFFF)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/LivingEntity;getMainHandItem()Lnet/minecraft/world/item/ItemStack;"))
-    public ItemStack getSelected(LivingEntity instance) {
+    @WrapOperation(method = "render(Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;ILnet/minecraft/world/entity/LivingEntity;FFFFFF)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/LivingEntity;getMainHandItem()Lnet/minecraft/world/item/ItemStack;"))
+    public ItemStack getSelected(LivingEntity instance, Operation<ItemStack> original) {
         if (instance instanceof Player player) {
             return InventoryHelper.getRealSelected(player.getInventory());
         } else {
-            return instance.getMainHandItem();
+            return original.call(instance);
         }
     }
 }

--- a/fabric/src/main/java/com/noxcrew/noxesium/mixin/rules/ItemInHandRendererMixin.java
+++ b/fabric/src/main/java/com/noxcrew/noxesium/mixin/rules/ItemInHandRendererMixin.java
@@ -12,7 +12,7 @@ import org.spongepowered.asm.mixin.injection.Redirect;
  * Overrides the item shown as being held in the main hand.
  */
 @Mixin(ItemInHandRenderer.class)
-public class ItemInHandRendererMixin {
+public abstract class ItemInHandRendererMixin {
 
     @Redirect(method = "tick()V", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/player/LocalPlayer;getMainHandItem()Lnet/minecraft/world/item/ItemStack;"))
     public ItemStack getSelected(LocalPlayer instance) {


### PR DESCRIPTION
Small pr but pre-emptively wrapping just saves future time / dev effort as it reduces the likeliness that a crash happens and a compat patch is required.

When an `@Redirect` handler calls the method that it targets it can be replaced with a `@WrapOperation` or `@WrapWithCondition` (depending on the context)

## Motivation:
`@Redirect`s are suitable if and only if you are unconditionally replacing the call and never calling the target and want to know about any crashes that result from another mod redirecting the same call. If any of those are not true then `@WrapOperation` or similar injectors are more suitable. 

`@Redirect`s do not chain, so if two mods try to redirect the same call, the game crashes. `@WrapOperation` supports chaining reducing the need for compat patches.

Example:
`@Redirect conflict. Skipping modid1.mixins.json:MixinName from mod modid1->@Redirect::handlerSignature with priority 1000, already redirected by modid2.mixins.json:MixinName from mod modid2->@Redirect::handlerSignature with priority 1000`
Causing
`Critical injection failure: Redirector handlerSignature in modid1.mixins.json:client.MixinName from mod modid1 failed injection check`
as there are no other valid places for the injector to inject (most mods have default injection requirement set to 1 in the `modid.mixin.json`)
https://github.com/Noxcrew/noxesium/blob/fc2e125e8562b629fdf12d164b72201c460506e1/fabric/src/main/resources/noxesium.mixins.json#L63-L65

### Note:
Specific redirect patterns such as:
https://github.com/Noxcrew/noxesium/blob/fc2e125e8562b629fdf12d164b72201c460506e1/fabric/src/main/java/com/noxcrew/noxesium/mixin/general/LocalPlayerMixin.java#L16-L22
can be replaced with `@WrapWithCondition` which also chains
```java
@WrapWithCondition(method = "respawn", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/KeyMapping;resetToggleKeys()V")) 
 public boolean onResetToggleKeys() { 
     return NoxesiumMod.getInstance().getConfig().resetToggleKeys;
}
```
Use cases require targeting void calls, or calls where the resultant return value is immediately popped from the stack (unused)