### PR TITLE
Fixes a NullPointerException thrown when a custom sound is started.

### DIFF
--- a/fabric/src/main/java/com/noxcrew/noxesium/feature/sounds/NoxesiumSoundModule.java
+++ b/fabric/src/main/java/com/noxcrew/noxesium/feature/sounds/NoxesiumSoundModule.java
@@ -51,7 +51,7 @@ public class NoxesiumSoundModule implements NoxesiumModule {
     @Nullable
     public NoxesiumSoundInstance getSound(int id) {
         NoxesiumSoundInstance soundInstance = sounds.get(id);
-        if (soundInstance.isStopped()) {
+        if (soundInstance != null && soundInstance.isStopped()) {
             sounds.remove(id);
             return null;
         }


### PR DESCRIPTION
Fixes a NullPointerException which is thrown when starting a custom sound (i have NO idea how i didn't catch this before it was merged...)