### PR TITLE
Fixes a NullPointerException when using with mod "Component Viewer"

### DIFF
--- a/fabric/src/main/java/com/noxcrew/noxesium/mixin/ui/render/OptionInstanceMixin.java
+++ b/fabric/src/main/java/com/noxcrew/noxesium/mixin/ui/render/OptionInstanceMixin.java
@@ -44,6 +44,8 @@ public abstract class OptionInstanceMixin<T> {
     private T overridePrioritizeChunkUpdates(T original) {
         var options = Minecraft.getInstance().options;
 
+        if (options == null) return original;
+
         // Ignore if we're in a nested settings menu override
         if (ServerRuleModule.noxesium$disableSettingOverrides) return original;
 


### PR DESCRIPTION
Fixes a crash that occurs on game launch when using "Noxesium" with mod "Component Viewer". See fixyldev/ComponentViewer#6.