### PR TITLE
Suggest fixes to `EntityRuleManager`

### DIFF
--- a/paper/src/main/kotlin/com/noxcrew/noxesium/paper/api/EntityRuleManager.kt
+++ b/paper/src/main/kotlin/com/noxcrew/noxesium/paper/api/EntityRuleManager.kt
@@ -1,6 +1,5 @@
 package com.noxcrew.noxesium.paper.api
 
-import com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent
 import com.noxcrew.noxesium.paper.api.network.clientbound.ClientboundSetExtraEntityDataPacket
 import com.noxcrew.noxesium.paper.api.rule.RemoteServerRule
 import io.papermc.paper.event.player.PlayerTrackEntityEvent
@@ -9,6 +8,7 @@ import org.bukkit.entity.Entity
 import org.bukkit.event.EventHandler
 import org.bukkit.event.HandlerList
 import org.bukkit.event.Listener
+import org.bukkit.event.entity.EntityRemoveEvent
 import java.util.WeakHashMap
 
 /**
@@ -116,7 +116,7 @@ public class EntityRuleManager(private val manager: NoxesiumManager) : Listener 
      * use a WeakHashMap.
      */
     @EventHandler
-    public fun onEntityRemoved(e: EntityRemoveFromWorldEvent) {
+    public fun onEntityRemoved(e: EntityRemoveEvent) {
         entities.remove(e.entity)
     }
 }

--- a/paper/src/main/kotlin/com/noxcrew/noxesium/paper/api/EntityRuleManager.kt
+++ b/paper/src/main/kotlin/com/noxcrew/noxesium/paper/api/EntityRuleManager.kt
@@ -7,6 +7,7 @@ import io.papermc.paper.event.player.PlayerTrackEntityEvent
 import org.bukkit.Bukkit
 import org.bukkit.entity.Entity
 import org.bukkit.event.EventHandler
+import org.bukkit.event.EventPriority
 import org.bukkit.event.HandlerList
 import org.bukkit.event.Listener
 import org.bukkit.event.entity.EntityRemoveEvent
@@ -113,7 +114,7 @@ public class EntityRuleManager(private val manager: NoxesiumManager) : Listener 
      * This will also send data about needed entities
      * when the player logs in / changes worlds.
      */
-    @EventHandler
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public fun onEntityShown(e: PlayerTrackEntityEvent) {
         val holder = entities[e.entity] ?: return
         val protocol = manager.getProtocolVersion(e.player) ?: return


### PR DESCRIPTION
Hey!

I tried the new `EntityRuleManager` and it didn't really work for me. 

The issues with it are:
- In the rule updates task in the `register()` func `holder.markAllUpdated()` was ran too early, making the loop never send updates.
- `onEntityShown` event would send packets just one moment too early and the client would throw `Received ClientboundSetExtraEntityDataPacket about unknown entity [id]` (probably an issue only on localhost actually, i don't have a server rn to test it on)

My suggested fixes are:
- Move the `holder.markAllUpdated()` to the end of the loop, so when filtering by `changePending` it can actually send data
- Add a 1 tick delay to `onEntityShown` event so the client has time to register the entity
- Remove `onNoxesiumPlayerRegistered` event, since when the player joins for each needed entity it's going to trigger the `onEntityShown` event

Open to suggestions!