### PR TITLE
Add ModifyVelocity and RemoveAllPotionEffects qib effects

### DIFF
--- a/api/src/main/java/com/noxcrew/noxesium/api/NoxesiumReferences.java
+++ b/api/src/main/java/com/noxcrew/noxesium/api/NoxesiumReferences.java
@@ -10,7 +10,7 @@ public class NoxesiumReferences {
      * of Noxesium is available on the client. The protocol version will increment every full release, as such
      * ít is recommended to work with >= comparisons.
      */
-    public static final int VERSION = 12;
+    public static final int VERSION = 13;
 
     /**
      * The name space to use for Noxesium.

--- a/api/src/main/java/com/noxcrew/noxesium/api/protocol/NoxesiumFeature.java
+++ b/api/src/main/java/com/noxcrew/noxesium/api/protocol/NoxesiumFeature.java
@@ -86,6 +86,11 @@ public enum NoxesiumFeature {
      * Fixes serialization of item stacks in rules.
      */
     FIXED_ITEM_STACK_SERIALIZATION(11),
+
+    /**
+     * Added support for ModifyVelocity and RemoveAllPotionEffects QibEffects.
+     */
+    NEW_QIB_EFFECTS(13),
     ;
 
     private final int minProtocolVersion;

--- a/api/src/main/java/com/noxcrew/noxesium/api/qib/QibEffect.java
+++ b/api/src/main/java/com/noxcrew/noxesium/api/qib/QibEffect.java
@@ -100,6 +100,13 @@ public sealed interface QibEffect {
     }
 
     /**
+     * Removes all client-authoritative potion effects.
+     * This only affects effects added by a [GivePotionEffect] effect.
+     */
+    public record RemoveAllPotionEffects() implements QibEffect {
+    }
+
+    /**
      * Forces the player to make an instant relative movement.
      */
     public record Move(
@@ -143,6 +150,22 @@ public sealed interface QibEffect {
         boolean pitchRelative,
         double strength,
         double limit
+    ) implements QibEffect {
+    }
+
+    /**
+     * Modifies each value of the player's velocity using provided value
+     * and expression.
+     * <p>
+     * Allows multiplying, adding, subtracting, dividing, and setting
+     */
+    public record ModifyVelocity(
+            double x,
+            QibOperation xOp,
+            double y,
+            QibOperation yOp,
+            double z,
+            QibOperation zOp
     ) implements QibEffect {
     }
 }

--- a/api/src/main/java/com/noxcrew/noxesium/api/qib/QibEffect.java
+++ b/api/src/main/java/com/noxcrew/noxesium/api/qib/QibEffect.java
@@ -157,7 +157,7 @@ public sealed interface QibEffect {
      * Modifies each value of the player's velocity using provided value
      * and expression.
      * <p>
-     * Allows multiplying, adding, subtracting, dividing, and setting
+     * Allows multiplying, adding, subtracting, dividing, setting and clamping
      */
     public record ModifyVelocity(
             double x,

--- a/api/src/main/java/com/noxcrew/noxesium/api/qib/QibEffectSerializer.java
+++ b/api/src/main/java/com/noxcrew/noxesium/api/qib/QibEffectSerializer.java
@@ -27,10 +27,12 @@ public class QibEffectSerializer implements JsonSerializer<QibEffect>, JsonDeser
             case "PlaySound" -> context.deserialize(data, QibEffect.PlaySound.class);
             case "GivePotionEffect" -> context.deserialize(data, QibEffect.GivePotionEffect.class);
             case "RemovePotionEffect" -> context.deserialize(data, QibEffect.RemovePotionEffect.class);
+            case "RemoveAllPotionEffects" -> context.deserialize(data, QibEffect.RemoveAllPotionEffects.class);
             case "Move" -> context.deserialize(data, QibEffect.Move.class);
             case "AddVelocity" -> context.deserialize(data, QibEffect.AddVelocity.class);
             case "SetVelocity" -> context.deserialize(data, QibEffect.SetVelocity.class);
             case "SetVelocityYawPitch" -> context.deserialize(data, QibEffect.SetVelocityYawPitch.class);
+            case "ModifyVelocity" -> context.deserialize(data, QibEffect.ModifyVelocity.class);
             default -> throw new JsonParseException("Invalid input type " + object.getAsJsonPrimitive("type").getAsString());
         };
     }

--- a/api/src/main/java/com/noxcrew/noxesium/api/qib/QibOperation.java
+++ b/api/src/main/java/com/noxcrew/noxesium/api/qib/QibOperation.java
@@ -1,5 +1,8 @@
 package com.noxcrew.noxesium.api.qib;
 
+/**
+ * Represents a mathematical operation/expression that can be applied to a value.
+ */
 public enum QibOperation {
     ADD,
     SET,
@@ -9,6 +12,22 @@ public enum QibOperation {
     MAX
     ;
 
+    /**
+     * Applies the operation to the given value with the given modifier resulting in the new value.
+     * <p/>
+     * The operation is applied as follows:
+     * <ul>
+     *     <li>{@link #ADD}: value + modifier</li>
+     *     <li>{@link #SET}: modifier</li>
+     *     <li>{@link #MUL}: value * modifier</li>
+     *     <li>{@link #DIV}: value / modifier</li>
+     *     <li>{@link #MIN}: min(value, modifier)</li>
+     *     <li>{@link #MAX}: max(value, modifier)</li>
+     * </ul>
+     * @param value the value to apply the operation to
+     * @param modifier the modifier to apply to the value
+     * @return the result of the operation
+     */
     public double apply(double value, double modifier) {
         return switch (this) {
             case ADD -> value + modifier;

--- a/api/src/main/java/com/noxcrew/noxesium/api/qib/QibOperation.java
+++ b/api/src/main/java/com/noxcrew/noxesium/api/qib/QibOperation.java
@@ -1,0 +1,22 @@
+package com.noxcrew.noxesium.api.qib;
+
+public enum QibOperation {
+    ADD,
+    SET,
+    MUL,
+    DIV,
+    MIN,
+    MAX
+    ;
+
+    public double apply(double value, double modifier) {
+        return switch (this) {
+            case ADD -> value + modifier;
+            case SET -> modifier;
+            case MUL -> value * modifier;
+            case DIV -> value / modifier;
+            case MIN -> Math.min(value, modifier);
+            case MAX -> Math.max(value, modifier);
+        };
+    }
+}

--- a/common/src/main/java/com/noxcrew/noxesium/feature/entity/QibBehaviorModule.java
+++ b/common/src/main/java/com/noxcrew/noxesium/feature/entity/QibBehaviorModule.java
@@ -285,6 +285,9 @@ public class QibBehaviorModule implements NoxesiumModule {
             case QibEffect.RemovePotionEffect removeEffect -> {
                 player.noxesium$removeClientsidePotionEffect(BuiltInRegistries.MOB_EFFECT.get(ResourceLocation.fromNamespaceAndPath(removeEffect.namespace(), removeEffect.path())).orElse(null));
             }
+            case QibEffect.RemoveAllPotionEffects ignored -> {
+                player.noxesium$clearClientsidePotionEffects();
+            }
             case QibEffect.Move move -> {
                 player.move(MoverType.SELF, new Vec3(move.x(), move.y(), move.z()));
             }
@@ -305,6 +308,14 @@ public class QibBehaviorModule implements NoxesiumModule {
                     Math.clamp(x * setVelocityYawPitch.strength(), -setVelocityYawPitch.limit(), setVelocityYawPitch.limit()),
                     Math.clamp(y * setVelocityYawPitch.strength(), -setVelocityYawPitch.limit(), setVelocityYawPitch.limit()),
                     Math.clamp(z * setVelocityYawPitch.strength(), -setVelocityYawPitch.limit(), setVelocityYawPitch.limit())
+                );
+            }
+            case QibEffect.ModifyVelocity modifyVelocity -> {
+                var current = player.getDeltaMovement();
+                player.setDeltaMovement(
+                        modifyVelocity.xOp().apply(current.x, modifyVelocity.x()),
+                        modifyVelocity.yOp().apply(current.y, modifyVelocity.y()),
+                        modifyVelocity.zOp().apply(current.z, modifyVelocity.z())
                 );
             }
             default -> throw new IllegalStateException("Unexpected value: " + effect);


### PR DESCRIPTION
### What does this PR do?

This PR adds to new effects, ModifyVelocity and RemoveAllPotionEffects.

ModifyVelocity:
> This effect allows a developer to modify each value of a players velocity instead of all.
> This is useful for chaining with other ModifyVelocity values or SetVelocityYawPitch as you can for example do the following:
> ```kt
> listOf(SetVelocityYawPitch(0, true, 0, true, 25, Short.MAX_VALUE), ModifyVelocity(1, MUL, 10, SET, 1, MUL))
> ```
> The above allows using the yaw and pitch for x and z but making y be a constant value

RemoveAllPotionEffects:
> This effect allows a developer to remove all the potion effects previously given by a qib, useful as a shortcut instead of sending multiple effect with all previous applied effects.
