### PR TITLE
feat: open link packet

### DIFF
--- a/api/src/main/java/com/noxcrew/noxesium/api/NoxesiumReferences.java
+++ b/api/src/main/java/com/noxcrew/noxesium/api/NoxesiumReferences.java
@@ -10,7 +10,7 @@ public class NoxesiumReferences {
      * of Noxesium is available on the client. The protocol version will increment every full release, as such
      * ít is recommended to work with >= comparisons.
      */
-    public static final int VERSION = 13;
+    public static final int VERSION = 14;
 
     /**
      * The name space to use for Noxesium.

--- a/api/src/main/java/com/noxcrew/noxesium/api/protocol/NoxesiumFeature.java
+++ b/api/src/main/java/com/noxcrew/noxesium/api/protocol/NoxesiumFeature.java
@@ -86,7 +86,6 @@ public enum NoxesiumFeature {
      * Fixes serialization of item stacks in rules.
      */
     FIXED_ITEM_STACK_SERIALIZATION(11),
-
     /**
      * Added support for ModifyVelocity and RemoveAllPotionEffects QibEffects.
      */
@@ -95,6 +94,10 @@ public enum NoxesiumFeature {
      * Adds an option to pre-charge tridents.
      */
     TRIDENT_PRE_CHARGE_OPTION(13),
+    /**
+     * Adds open link packet
+     */
+    OPEN_LINK_PACKET(14),
     ;
 
     private final int minProtocolVersion;

--- a/common/src/main/java/com/noxcrew/noxesium/network/NoxesiumPackets.java
+++ b/common/src/main/java/com/noxcrew/noxesium/network/NoxesiumPackets.java
@@ -10,6 +10,7 @@ import com.noxcrew.noxesium.network.clientbound.ClientboundCustomSoundStartPacke
 import com.noxcrew.noxesium.network.clientbound.ClientboundCustomSoundStopPacket;
 import com.noxcrew.noxesium.network.clientbound.ClientboundMccGameStatePacket;
 import com.noxcrew.noxesium.network.clientbound.ClientboundMccServerPacket;
+import com.noxcrew.noxesium.network.clientbound.ClientboundOpenLinkPacket;
 import com.noxcrew.noxesium.network.clientbound.ClientboundResetExtraEntityDataPacket;
 import com.noxcrew.noxesium.network.clientbound.ClientboundResetPacket;
 import com.noxcrew.noxesium.network.clientbound.ClientboundResetServerRulesPacket;
@@ -83,6 +84,9 @@ public class NoxesiumPackets {
             NoxesiumPackets.client("change_extra_entity_data", ClientboundSetExtraEntityDataPacket.STREAM_CODEC);
     public static final NoxesiumPayloadType<ClientboundResetExtraEntityDataPacket> CLIENT_RESET_EXTRA_ENTITY_DATA =
             NoxesiumPackets.client("reset_extra_entity_data", ClientboundResetExtraEntityDataPacket.STREAM_CODEC);
+
+    public static final NoxesiumPayloadType<ClientboundOpenLinkPacket> CLIENT_OPEN_LINK =
+            NoxesiumPackets.client("open_link", ClientboundOpenLinkPacket.STREAM_CODEC);
 
     /**
      * Returns an unmodifiable copy of all registered groups.

--- a/common/src/main/java/com/noxcrew/noxesium/network/clientbound/ClientboundOpenLinkPacket.java
+++ b/common/src/main/java/com/noxcrew/noxesium/network/clientbound/ClientboundOpenLinkPacket.java
@@ -1,0 +1,38 @@
+package com.noxcrew.noxesium.network.clientbound;
+
+import com.noxcrew.noxesium.network.NoxesiumPacket;
+import com.noxcrew.noxesium.network.NoxesiumPackets;
+import com.noxcrew.noxesium.network.NoxesiumPayloadType;
+import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.ComponentSerialization;
+import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Sent by the server to open a link dialog on the client.
+ */
+public record ClientboundOpenLinkPacket(@Nullable Component text, String url) implements NoxesiumPacket {
+    public static final StreamCodec<RegistryFriendlyByteBuf, ClientboundOpenLinkPacket> STREAM_CODEC =
+            CustomPacketPayload.codec(ClientboundOpenLinkPacket::write, ClientboundOpenLinkPacket::new);
+
+    private ClientboundOpenLinkPacket(RegistryFriendlyByteBuf buf) {
+        this(buf.readBoolean() ? ComponentSerialization.STREAM_CODEC.decode(buf) : null, buf.readUtf());
+    }
+
+    private void write(RegistryFriendlyByteBuf buf) {
+        if (text != null) {
+            buf.writeBoolean(true);
+            ComponentSerialization.STREAM_CODEC.encode(buf, text);
+        } else {
+            buf.writeBoolean(false);
+        }
+        buf.writeUtf(url);
+    }
+
+    @Override
+    public NoxesiumPayloadType<?> noxesiumType() {
+        return NoxesiumPackets.CLIENT_OPEN_LINK;
+    }
+}

--- a/paper/src/main/kotlin/com/noxcrew/noxesium/paper/api/network/NoxesiumPackets.kt
+++ b/paper/src/main/kotlin/com/noxcrew/noxesium/paper/api/network/NoxesiumPackets.kt
@@ -6,6 +6,7 @@ import com.noxcrew.noxesium.paper.api.network.clientbound.ClientboundCustomSound
 import com.noxcrew.noxesium.paper.api.network.clientbound.ClientboundCustomSoundStopPacket
 import com.noxcrew.noxesium.paper.api.network.clientbound.ClientboundMccGameStatePacket
 import com.noxcrew.noxesium.paper.api.network.clientbound.ClientboundMccServerPacket
+import com.noxcrew.noxesium.paper.api.network.clientbound.ClientboundOpenLinkPacket
 import com.noxcrew.noxesium.paper.api.network.clientbound.ClientboundResetExtraEntityDataPacket
 import com.noxcrew.noxesium.paper.api.network.clientbound.ClientboundResetPacket
 import com.noxcrew.noxesium.paper.api.network.clientbound.ClientboundResetServerRulesPacket
@@ -45,6 +46,8 @@ public object NoxesiumPackets {
 
     public val CLIENT_CHANGE_EXTRA_ENTITY_DATA: PacketType<ClientboundCustomSoundStopPacket> = client("change_extra_entity_data")
     public val CLIENT_RESET_EXTRA_ENTITY_DATA: PacketType<ClientboundResetExtraEntityDataPacket> = client("reset_extra_entity_data")
+
+    public val CLIENT_OPEN_LINK: PacketType<ClientboundOpenLinkPacket> = client("open_link")
 
     /** All registered client-bound packets. */
     public val clientboundPackets: Map<String, PacketType<*>>

--- a/paper/src/main/kotlin/com/noxcrew/noxesium/paper/api/network/clientbound/ClientboundOpenLinkPacket.kt
+++ b/paper/src/main/kotlin/com/noxcrew/noxesium/paper/api/network/clientbound/ClientboundOpenLinkPacket.kt
@@ -1,0 +1,13 @@
+package com.noxcrew.noxesium.paper.api.network.clientbound
+
+import com.noxcrew.noxesium.paper.api.network.NoxesiumPacket
+import com.noxcrew.noxesium.paper.api.network.NoxesiumPackets
+import net.kyori.adventure.text.Component
+
+/**
+ * Sent by the server to open a link dialog on the client.
+ */
+public data class ClientboundOpenLinkPacket(
+    public val text: Component?,
+    public val url: String,
+) : NoxesiumPacket(NoxesiumPackets.CLIENT_OPEN_LINK)

--- a/paper/src/main/kotlin/com/noxcrew/noxesium/paper/v2/NoxesiumListenerV2.kt
+++ b/paper/src/main/kotlin/com/noxcrew/noxesium/paper/v2/NoxesiumListenerV2.kt
@@ -14,6 +14,7 @@ import com.noxcrew.noxesium.paper.api.network.clientbound.ClientboundCustomSound
 import com.noxcrew.noxesium.paper.api.network.clientbound.ClientboundCustomSoundStopPacket
 import com.noxcrew.noxesium.paper.api.network.clientbound.ClientboundMccGameStatePacket
 import com.noxcrew.noxesium.paper.api.network.clientbound.ClientboundMccServerPacket
+import com.noxcrew.noxesium.paper.api.network.clientbound.ClientboundOpenLinkPacket
 import com.noxcrew.noxesium.paper.api.network.clientbound.ClientboundResetExtraEntityDataPacket
 import com.noxcrew.noxesium.paper.api.network.clientbound.ClientboundResetPacket
 import com.noxcrew.noxesium.paper.api.network.clientbound.ClientboundResetServerRulesPacket
@@ -21,8 +22,10 @@ import com.noxcrew.noxesium.paper.api.network.clientbound.ClientboundServerInfor
 import com.noxcrew.noxesium.paper.api.network.clientbound.ClientboundSetExtraEntityDataPacket
 import com.noxcrew.noxesium.paper.api.network.serverbound.handle
 import com.noxcrew.noxesium.paper.api.readPluginMessage
+import io.papermc.paper.adventure.PaperAdventure
 import it.unimi.dsi.fastutil.ints.IntImmutableList
 import net.kyori.adventure.key.Key
+import net.minecraft.network.chat.ComponentSerialization
 import net.minecraft.network.protocol.common.ClientboundCustomPayloadPacket
 import org.bukkit.entity.Player
 import org.bukkit.event.EventHandler
@@ -155,6 +158,12 @@ public class NoxesiumListenerV2(
                 is ClientboundResetExtraEntityDataPacket -> {
                     buffer.writeVarInt(packet.entityId)
                     buffer.writeIntIdList(packet.indices)
+                }
+
+                is ClientboundOpenLinkPacket -> {
+                    buffer.writeBoolean(packet.text != null)
+                    packet.text?.let { ComponentSerialization.STREAM_CODEC.encode(buffer, PaperAdventure.asVanilla(it)) }
+                    buffer.writeUtf(packet.url)
                 }
             }
         }


### PR DESCRIPTION
### Changes

- adds a new packet to open the link dialog to a user with customizable text.
   - Note: It always with append the normal minecraft prompt message of would you like the open the link and also includes the link they will be going to

Preview of a packet containing `test\nanotherline` and `https://google.com`

![image](https://github.com/user-attachments/assets/915618f9-0ffa-49f1-9b9a-a7883e5a1aa7)
