### PR TITLE
Add support for `noxesium:immovable` being in root tag of custom data component

### DIFF
--- a/common/src/main/java/com/noxcrew/noxesium/mixin/feature/UnmovableInventoryMixin.java
+++ b/common/src/main/java/com/noxcrew/noxesium/mixin/feature/UnmovableInventoryMixin.java
@@ -1,22 +1,23 @@
 package com.noxcrew.noxesium.mixin.feature;
 
-import static com.noxcrew.noxesium.api.NoxesiumReferences.BUKKIT_COMPOUND_ID;
-import static com.noxcrew.noxesium.api.NoxesiumReferences.IMMOVABLE_TAG;
-
 import com.llamalad7.mixinextras.sugar.Local;
 import net.minecraft.core.component.DataComponents;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.component.CustomData;
+import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
+import static com.noxcrew.noxesium.api.NoxesiumReferences.BUKKIT_COMPOUND_ID;
+import static com.noxcrew.noxesium.api.NoxesiumReferences.IMMOVABLE_TAG;
+
 /**
  * Mixin for preventing items dropped from the hotbar.
- * This only prevent items with the {@link com.noxcrew.noxesium.api.NoxesiumReferences#IMMOVABLE_TAG} from being moved.
+ * This only prevents items with the {@link com.noxcrew.noxesium.api.NoxesiumReferences#IMMOVABLE_TAG} from being moved.
  */
 @Mixin(Inventory.class)
 public abstract class UnmovableInventoryMixin {
@@ -29,11 +30,12 @@ public abstract class UnmovableInventoryMixin {
             final boolean bl, final CallbackInfoReturnable<ItemStack> cir, @Local final ItemStack stack) {
         final CustomData data = stack.get(DataComponents.CUSTOM_DATA);
         if (data == null) return;
+
         final CompoundTag tag = data.getUnsafe();
         if (tag == null) return;
 
-        final CompoundTag bukkit = tag.getCompound(BUKKIT_COMPOUND_ID).orElse(null);
-        if (bukkit == null || !bukkit.contains(IMMOVABLE_TAG)) return;
+        @Nullable CompoundTag immovableTagContainer = tag.contains(IMMOVABLE_TAG) ? tag : tag.getCompound(BUKKIT_COMPOUND_ID).orElse(null);
+        if (immovableTagContainer == null || !immovableTagContainer.contains(IMMOVABLE_TAG)) return;
 
         cir.setReturnValue(ItemStack.EMPTY);
     }

--- a/common/src/main/java/com/noxcrew/noxesium/mixin/feature/UnmovableSlotMixin.java
+++ b/common/src/main/java/com/noxcrew/noxesium/mixin/feature/UnmovableSlotMixin.java
@@ -1,23 +1,24 @@
 package com.noxcrew.noxesium.mixin.feature;
 
-import static com.noxcrew.noxesium.api.NoxesiumReferences.BUKKIT_COMPOUND_ID;
-import static com.noxcrew.noxesium.api.NoxesiumReferences.IMMOVABLE_TAG;
-
 import net.minecraft.core.component.DataComponents;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.Slot;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.component.CustomData;
+import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
+import static com.noxcrew.noxesium.api.NoxesiumReferences.BUKKIT_COMPOUND_ID;
+import static com.noxcrew.noxesium.api.NoxesiumReferences.IMMOVABLE_TAG;
+
 /**
  * Mixin for preventing items from being moved inside custom inventories.
- * This only prevent items with the {@link com.noxcrew.noxesium.api.NoxesiumReferences#IMMOVABLE_TAG} from being moved.
+ * This only prevents items with the {@link com.noxcrew.noxesium.api.NoxesiumReferences#IMMOVABLE_TAG} from being moved.
  * This is done to improve using menus, as there won't be any flickering when clicking on buttons anymore.
  */
 @Mixin(Slot.class)
@@ -33,11 +34,12 @@ public abstract class UnmovableSlotMixin {
 
         final CustomData data = itemStack.get(DataComponents.CUSTOM_DATA);
         if (data == null) return;
-        final CompoundTag tag = data.getUnsafe();
+
+        final CompoundTag tag = data.getUnsafe() ;
         if (tag == null) return;
 
-        final CompoundTag bukkit = tag.getCompound(BUKKIT_COMPOUND_ID).orElse(null);
-        if (bukkit == null || !bukkit.contains(IMMOVABLE_TAG)) return;
+        @Nullable CompoundTag immovableTagContainer = tag.contains(IMMOVABLE_TAG) ? tag : tag.getCompound(BUKKIT_COMPOUND_ID).orElse(null);
+        if (immovableTagContainer == null || !immovableTagContainer.contains(IMMOVABLE_TAG)) return;
 
         cir.setReturnValue(false);
     }


### PR DESCRIPTION
The philosophy here is that not everyone uses bukkit based platforms to make their servers. Lot of projects these days like Xenyria, my server projects or servers on based minestom run custom server implementations and it is little annoying having to manually make `PublicBukkitValues` compound and put the tag in that instead of just the root tag. 

This PR adds support for the tag being in both `PublicBukkitValues` compound and the root tag of the custom data component