### PR TITLE
feat: Added new server rule to dictate if certain block updates should be server-authoritative 

### DIFF
--- a/api/src/main/java/com/noxcrew/noxesium/api/NoxesiumReferences.java
+++ b/api/src/main/java/com/noxcrew/noxesium/api/NoxesiumReferences.java
@@ -13,7 +13,7 @@ public class NoxesiumReferences {
      * Add the versions when this value changes to [NoxesiumListCommand] to serve as a proper record
      * of when it was raised. Protocol version should only raise once per release.
      */
-    public static final int VERSION = 18;
+    public static final int VERSION = 19;
 
     /**
      * The name space to use for Noxesium.

--- a/api/src/main/java/com/noxcrew/noxesium/api/NoxesiumReferences.java
+++ b/api/src/main/java/com/noxcrew/noxesium/api/NoxesiumReferences.java
@@ -13,7 +13,7 @@ public class NoxesiumReferences {
      * Add the versions when this value changes to [NoxesiumListCommand] to serve as a proper record
      * of when it was raised. Protocol version should only raise once per release.
      */
-    public static final int VERSION = 19;
+    public static final int VERSION = 18;
 
     /**
      * The name space to use for Noxesium.

--- a/api/src/main/java/com/noxcrew/noxesium/api/protocol/rule/ServerRuleIndices.java
+++ b/api/src/main/java/com/noxcrew/noxesium/api/protocol/rule/ServerRuleIndices.java
@@ -124,4 +124,10 @@ public class ServerRuleIndices {
      * Restricts available debug options available to the player.
      */
     public static final int RESTRICT_DEBUG_OPTIONS = 19;
+
+    /**
+     * Allows tripwires and note blocks to have server authoritative updates. This means the client does not
+     * attempt to make any local block state changes for these blocks.
+     */
+    public static final int SERVER_AUTHORITATIVE_BLOCK_UPDATES = 20;
 }

--- a/common/src/main/java/com/noxcrew/noxesium/feature/rule/ServerRules.java
+++ b/common/src/main/java/com/noxcrew/noxesium/feature/rule/ServerRules.java
@@ -130,6 +130,14 @@ public class ServerRules {
                 }
             }));
 
+    /**
+     * Allows tripwires and note blocks to have server authoritative updates. This means the client does not
+     * attempt to make any local block state changes for these blocks.
+     */
+    public static ClientServerRule<Boolean> SERVER_AUTHORITATIVE_BLOCK_UPDATES =
+            register(new BooleanServerRule(ServerRuleIndices.SERVER_AUTHORITATIVE_BLOCK_UPDATES, false));
+
+
     static {
         // Register dummy listeners for removed rules so it doesn't
         // throw errors on old servers.

--- a/common/src/main/java/com/noxcrew/noxesium/mixin/feature/ServerAuthoritativeNoteBlockUpdatesMixin.java
+++ b/common/src/main/java/com/noxcrew/noxesium/mixin/feature/ServerAuthoritativeNoteBlockUpdatesMixin.java
@@ -1,0 +1,39 @@
+package com.noxcrew.noxesium.mixin.feature;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.util.RandomSource;
+import net.minecraft.world.item.context.BlockPlaceContext;
+import net.minecraft.world.level.LevelReader;
+import net.minecraft.world.level.ScheduledTickAccess;
+import net.minecraft.world.level.block.NoteBlock;
+import net.minecraft.world.level.block.state.BlockState;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+/**
+ * Allows note blocks to have server authoritative updates
+ * this means the client does not attempt to make any
+ * local block state changes.
+ */
+@Mixin(value = {NoteBlock.class})
+public class ServerAuthoritativeNoteBlockUpdatesMixin {
+
+    @Inject(method = "getStateForPlacement", at = @At("HEAD"), cancellable = true)
+    public void onGetStateForPlacement(BlockPlaceContext context, CallbackInfoReturnable<BlockState> cir) {
+        if (!shouldUseServerAuthoritativeUpdates()) return;
+        cir.setReturnValue(((NoteBlock) (Object) this).defaultBlockState());
+    }
+
+    @Inject(method = "updateShape", at = @At("HEAD"), cancellable = true)
+    public void onUpdateShape(BlockState p_57645_, LevelReader p_374437_, ScheduledTickAccess p_374214_, BlockPos p_57649_, Direction p_57646_, BlockPos p_57650_, BlockState p_57647_, RandomSource p_374065_, CallbackInfoReturnable<BlockState> cir) {
+        if (!shouldUseServerAuthoritativeUpdates()) return;
+        cir.setReturnValue(p_57645_);
+    }
+
+    private boolean shouldUseServerAuthoritativeUpdates() {
+        return true;
+    }
+}

--- a/common/src/main/java/com/noxcrew/noxesium/mixin/feature/ServerAuthoritativeNoteBlockUpdatesMixin.java
+++ b/common/src/main/java/com/noxcrew/noxesium/mixin/feature/ServerAuthoritativeNoteBlockUpdatesMixin.java
@@ -22,13 +22,13 @@ public class ServerAuthoritativeNoteBlockUpdatesMixin {
 
     @Inject(method = "getStateForPlacement", at = @At("HEAD"), cancellable = true)
     public void onGetStateForPlacement(BlockPlaceContext context, CallbackInfoReturnable<BlockState> cir) {
-        if (ServerRules.SERVER_AUTHORITATIVE_BLOCK_UPDATES.getValue()) return;
+        if (!ServerRules.SERVER_AUTHORITATIVE_BLOCK_UPDATES.getValue()) return;
         cir.setReturnValue(((NoteBlock) (Object) this).defaultBlockState());
     }
 
     @Inject(method = "updateShape", at = @At("HEAD"), cancellable = true)
     public void onUpdateShape(BlockState p_57645_, LevelReader p_374437_, ScheduledTickAccess p_374214_, BlockPos p_57649_, Direction p_57646_, BlockPos p_57650_, BlockState p_57647_, RandomSource p_374065_, CallbackInfoReturnable<BlockState> cir) {
-        if (ServerRules.SERVER_AUTHORITATIVE_BLOCK_UPDATES.getValue()) return;
+        if (!ServerRules.SERVER_AUTHORITATIVE_BLOCK_UPDATES.getValue()) return;
         cir.setReturnValue(p_57645_);
     }
 

--- a/common/src/main/java/com/noxcrew/noxesium/mixin/feature/ServerAuthoritativeNoteBlockUpdatesMixin.java
+++ b/common/src/main/java/com/noxcrew/noxesium/mixin/feature/ServerAuthoritativeNoteBlockUpdatesMixin.java
@@ -1,5 +1,6 @@
 package com.noxcrew.noxesium.mixin.feature;
 
+import com.noxcrew.noxesium.feature.rule.ServerRules;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.util.RandomSource;
@@ -14,26 +15,21 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 /**
- * Allows note blocks to have server authoritative updates
- * this means the client does not attempt to make any
- * local block state changes.
+ * Mixin for enforcing note block server updates.
  */
 @Mixin(value = {NoteBlock.class})
 public class ServerAuthoritativeNoteBlockUpdatesMixin {
 
     @Inject(method = "getStateForPlacement", at = @At("HEAD"), cancellable = true)
     public void onGetStateForPlacement(BlockPlaceContext context, CallbackInfoReturnable<BlockState> cir) {
-        if (!shouldUseServerAuthoritativeUpdates()) return;
+        if (ServerRules.SERVER_AUTHORITATIVE_BLOCK_UPDATES.getValue()) return;
         cir.setReturnValue(((NoteBlock) (Object) this).defaultBlockState());
     }
 
     @Inject(method = "updateShape", at = @At("HEAD"), cancellable = true)
     public void onUpdateShape(BlockState p_57645_, LevelReader p_374437_, ScheduledTickAccess p_374214_, BlockPos p_57649_, Direction p_57646_, BlockPos p_57650_, BlockState p_57647_, RandomSource p_374065_, CallbackInfoReturnable<BlockState> cir) {
-        if (!shouldUseServerAuthoritativeUpdates()) return;
+        if (ServerRules.SERVER_AUTHORITATIVE_BLOCK_UPDATES.getValue()) return;
         cir.setReturnValue(p_57645_);
     }
 
-    private boolean shouldUseServerAuthoritativeUpdates() {
-        return true;
-    }
 }

--- a/common/src/main/java/com/noxcrew/noxesium/mixin/feature/ServerAuthoritativeTripwireUpdatesMixin.java
+++ b/common/src/main/java/com/noxcrew/noxesium/mixin/feature/ServerAuthoritativeTripwireUpdatesMixin.java
@@ -16,6 +16,8 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
+import java.util.logging.Logger;
+
 /**
  * Mixin for enforcing note block server updates.
  */
@@ -24,19 +26,19 @@ public class ServerAuthoritativeTripwireUpdatesMixin {
 
     @Inject(method = "getStateForPlacement", at = @At("HEAD"), cancellable = true)
     public void onGetStateForPlacement(BlockPlaceContext context, CallbackInfoReturnable<BlockState> cir) {
-        if (ServerRules.SERVER_AUTHORITATIVE_BLOCK_UPDATES.getValue()) return;
+        if (!ServerRules.SERVER_AUTHORITATIVE_BLOCK_UPDATES.getValue()) return;
         cir.setReturnValue(((TripWireBlock) (Object) this).defaultBlockState());
     }
 
     @Inject(method = "updateShape", at = @At("HEAD"), cancellable = true)
     public void onUpdateShape(BlockState p_57645_, LevelReader p_374437_, ScheduledTickAccess p_374214_, BlockPos p_57649_, Direction p_57646_, BlockPos p_57650_, BlockState p_57647_, RandomSource p_374065_, CallbackInfoReturnable<BlockState> cir) {
-        if (ServerRules.SERVER_AUTHORITATIVE_BLOCK_UPDATES.getValue()) return;
+        if (!ServerRules.SERVER_AUTHORITATIVE_BLOCK_UPDATES.getValue()) return;
         cir.setReturnValue(p_57645_);
     }
 
     @Inject(method = "onPlace", at = @At("HEAD"), cancellable = true)
     public void onPlace(BlockState state, Level level, BlockPos pos, BlockState oldState, boolean moved, CallbackInfo ci) {
-        if (ServerRules.SERVER_AUTHORITATIVE_BLOCK_UPDATES.getValue()) return;
+        if (!ServerRules.SERVER_AUTHORITATIVE_BLOCK_UPDATES.getValue()) return;
         ci.cancel();
     }
 

--- a/common/src/main/java/com/noxcrew/noxesium/mixin/feature/ServerAuthoritativeTripwireUpdatesMixin.java
+++ b/common/src/main/java/com/noxcrew/noxesium/mixin/feature/ServerAuthoritativeTripwireUpdatesMixin.java
@@ -1,0 +1,48 @@
+package com.noxcrew.noxesium.mixin.feature;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.util.RandomSource;
+import net.minecraft.world.item.context.BlockPlaceContext;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.LevelReader;
+import net.minecraft.world.level.ScheduledTickAccess;
+import net.minecraft.world.level.block.TripWireBlock;
+import net.minecraft.world.level.block.state.BlockState;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+/**
+ * Allows tripwires to have server authoritative updates
+ * this means the client does not attempt to make any
+ * local block state changes.
+ */
+@Mixin(value = {TripWireBlock.class})
+public class ServerAuthoritativeTripwireUpdatesMixin {
+
+    @Inject(method = "getStateForPlacement", at = @At("HEAD"), cancellable = true)
+    public void onGetStateForPlacement(BlockPlaceContext context, CallbackInfoReturnable<BlockState> cir) {
+        if (!shouldUseServerAuthoritativeUpdates()) return;
+        cir.setReturnValue(((TripWireBlock) (Object) this).defaultBlockState());
+    }
+
+    @Inject(method = "updateShape", at = @At("HEAD"), cancellable = true)
+    public void onUpdateShape(BlockState p_57645_, LevelReader p_374437_, ScheduledTickAccess p_374214_, BlockPos p_57649_, Direction p_57646_, BlockPos p_57650_, BlockState p_57647_, RandomSource p_374065_, CallbackInfoReturnable<BlockState> cir) {
+        if (!shouldUseServerAuthoritativeUpdates()) return;
+        cir.setReturnValue(p_57645_);
+    }
+
+    @Inject(method = "onPlace", at = @At("HEAD"), cancellable = true)
+    public void onPlace(BlockState state, Level level, BlockPos pos, BlockState oldState, boolean moved, CallbackInfo ci) {
+        if (!shouldUseServerAuthoritativeUpdates()) return;
+        ci.cancel();
+    }
+
+    private boolean shouldUseServerAuthoritativeUpdates() {
+        return true;
+    }
+}
+

--- a/common/src/main/java/com/noxcrew/noxesium/mixin/feature/ServerAuthoritativeTripwireUpdatesMixin.java
+++ b/common/src/main/java/com/noxcrew/noxesium/mixin/feature/ServerAuthoritativeTripwireUpdatesMixin.java
@@ -1,5 +1,6 @@
 package com.noxcrew.noxesium.mixin.feature;
 
+import com.noxcrew.noxesium.feature.rule.ServerRules;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.util.RandomSource;
@@ -16,33 +17,28 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 /**
- * Allows tripwires to have server authoritative updates
- * this means the client does not attempt to make any
- * local block state changes.
+ * Mixin for enforcing note block server updates.
  */
 @Mixin(value = {TripWireBlock.class})
 public class ServerAuthoritativeTripwireUpdatesMixin {
 
     @Inject(method = "getStateForPlacement", at = @At("HEAD"), cancellable = true)
     public void onGetStateForPlacement(BlockPlaceContext context, CallbackInfoReturnable<BlockState> cir) {
-        if (!shouldUseServerAuthoritativeUpdates()) return;
+        if (ServerRules.SERVER_AUTHORITATIVE_BLOCK_UPDATES.getValue()) return;
         cir.setReturnValue(((TripWireBlock) (Object) this).defaultBlockState());
     }
 
     @Inject(method = "updateShape", at = @At("HEAD"), cancellable = true)
     public void onUpdateShape(BlockState p_57645_, LevelReader p_374437_, ScheduledTickAccess p_374214_, BlockPos p_57649_, Direction p_57646_, BlockPos p_57650_, BlockState p_57647_, RandomSource p_374065_, CallbackInfoReturnable<BlockState> cir) {
-        if (!shouldUseServerAuthoritativeUpdates()) return;
+        if (ServerRules.SERVER_AUTHORITATIVE_BLOCK_UPDATES.getValue()) return;
         cir.setReturnValue(p_57645_);
     }
 
     @Inject(method = "onPlace", at = @At("HEAD"), cancellable = true)
     public void onPlace(BlockState state, Level level, BlockPos pos, BlockState oldState, boolean moved, CallbackInfo ci) {
-        if (!shouldUseServerAuthoritativeUpdates()) return;
+        if (ServerRules.SERVER_AUTHORITATIVE_BLOCK_UPDATES.getValue()) return;
         ci.cancel();
     }
 
-    private boolean shouldUseServerAuthoritativeUpdates() {
-        return true;
-    }
 }
 

--- a/common/src/main/resources/noxesium-common.mixins.json
+++ b/common/src/main/resources/noxesium-common.mixins.json
@@ -27,6 +27,8 @@
     "feature.component.ext.SkinManagerExt",
     "feature.component.ext.SkinTextureDownloaderExt",
     "feature.component.ext.TextureCacheExt",
+    "feature.ServerAuthoritativeNoteBlockUpdatesMixin",
+    "feature.ServerAuthoritativeTripwireUpdatesMixin",
     "font.PreparedTextBuilderMixin",
     "rules.BoatCollisionMixin",
     "rules.CustomCreativeReloadMixin",

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ org.gradle.jvmargs=-Xmx2G
 org.gradle.parallel=true
 
 # Mod properties
-mod_version=2.7.8
+mod_version=2.7.9
 
 # Enabled other mods in development environment
 enableSodium = true

--- a/paper/src/main/kotlin/com/noxcrew/noxesium/paper/api/rule/ServerRules.kt
+++ b/paper/src/main/kotlin/com/noxcrew/noxesium/paper/api/rule/ServerRules.kt
@@ -104,6 +104,13 @@ public class ServerRules(
      */
     public var restrictDebugOptions: RuleFunction<List<Int>> = register(ServerRuleIndices.RESTRICT_DEBUG_OPTIONS, 18, ::IntListServerRule)
 
+    /**
+     * Allows tripwires and note blocks to have server authoritative updates. This means the client does not
+     * attempt to make any local block state changes for these blocks.
+     */
+    public var serverAuthoritativeBlockUpdates: RuleFunction<List<Int>> = register(ServerRuleIndices.SERVER_AUTHORITATIVE_BLOCK_UPDATES, 19, ::BooleanServerRule)
+
+
     /** Registers a new [rule]. */
     private fun <T : Any> register(index: Int, minimumProtocol: Int, rule: (Int) -> RemoteServerRule<T>,): RuleFunction<T> {
         val function = RuleFunction(index, rule)


### PR DESCRIPTION
## Changes:
- Adds new `SERVER_AUTHORITATIVE_BLOCK_UPDATES` ServerRule which dictates if block updates from tripwire and noteblocks (commonly used for custom models / decoration) should be handled server-side.

Example preview, vanilla behavior, without ServerRule enabled. Then behavior with the ServerRule enabled:

![blockupdatesexample](https://github.com/user-attachments/assets/356d05ee-0b17-47ae-85bc-905b12c6368b)
