### PR TITLE
Chat width now sent with ClientSettings

### DIFF
--- a/api/src/main/java/com/noxcrew/noxesium/core/feature/ClientSettings.java
+++ b/api/src/main/java/com/noxcrew/noxesium/core/feature/ClientSettings.java
@@ -11,6 +11,7 @@ package com.noxcrew.noxesium.core.feature;
  * @param enforceUnicode          Whether unicode fonts are being enforced.
  * @param touchScreenMode         Whether touch screen mode is enabled.
  * @param notificationDisplayTime What the notification display time is set to.
+ * @param chatWidth               The chat width (this is given on a scale 0-1 with 0 being 40px 1 being 320px), if unknown is -1.
  */
 public record ClientSettings(
         int configuredGuiScale,
@@ -19,4 +20,5 @@ public record ClientSettings(
         int height,
         boolean enforceUnicode,
         boolean touchScreenMode,
-        double notificationDisplayTime) {}
+        double notificationDisplayTime,
+        double chatWidth) {}

--- a/fabric/src/main/java/com/noxcrew/noxesium/core/fabric/feature/SyncGuiScale.java
+++ b/fabric/src/main/java/com/noxcrew/noxesium/core/fabric/feature/SyncGuiScale.java
@@ -35,6 +35,7 @@ public class SyncGuiScale extends NoxesiumFeature {
                 window.getGuiScaledHeight(),
                 Minecraft.getInstance().isEnforceUnicode(),
                 options.touchscreen().get(),
-                options.notificationDisplayTime().get())));
+                options.notificationDisplayTime().get(),
+                options.chatWidth().get())));
     }
 }

--- a/fabric/src/main/java/com/noxcrew/noxesium/core/fabric/mixin/feature/OptionInstanceMixin.java
+++ b/fabric/src/main/java/com/noxcrew/noxesium/core/fabric/mixin/feature/OptionInstanceMixin.java
@@ -33,7 +33,9 @@ public abstract class OptionInstanceMixin<T> {
                                     "Lnet/minecraft/client/OptionInstance;onValueUpdate:Ljava/util/function/Consumer;"))
     private Consumer<T> updateNoxesiumOptions(OptionInstance<T> instance, Operation<Consumer<T>> original) {
         var options = Minecraft.getInstance().options;
-        if (instance == options.touchscreen() || instance == options.notificationDisplayTime()) {
+        if (instance == options.touchscreen()
+                || instance == options.notificationDisplayTime()
+                || instance == options.chatWidth()) {
             NoxesiumApi.getInstance().getFeatureOptional(SyncGuiScale.class).ifPresent(SyncGuiScale::syncGuiScale);
         }
         return original.call(instance);


### PR DESCRIPTION
Client now also sends chat width with ClientSettings, the chat width is sent as a double between 0 and 1, with 0 representing a chat width of 40 pixels, and 1 representing a chat width of 320 pixels. If chat width is not present when ClientSettings are sent to the server it defaults to -1.