### PR TITLE
Allow different keys in registry to have the same values

### DIFF
--- a/api/src/main/java/com/noxcrew/noxesium/api/registry/ClientNoxesiumRegistry.java
+++ b/api/src/main/java/com/noxcrew/noxesium/api/registry/ClientNoxesiumRegistry.java
@@ -23,8 +23,10 @@ public class ClientNoxesiumRegistry<T> extends NoxesiumRegistry<T> {
      * Resets only the mappings provided by the server.
      */
     public void resetMappings() {
-        idToValue.clear();
-        valueToId.clear();
+        idToEntry.clear();
+        for (var entry : keyToEntry.values()) {
+            entry.setId(-1);
+        }
     }
 
     /**
@@ -32,10 +34,10 @@ public class ClientNoxesiumRegistry<T> extends NoxesiumRegistry<T> {
      * Silently fails if the key is not known.
      */
     public boolean registerMapping(Key key, int id) {
-        var value = getByKey(key);
-        if (value != null) {
-            idToValue.put(id, value);
-            valueToId.put(value, id);
+        var entry = keyToEntry.get(key);
+        if (entry != null) {
+            entry.setId(id);
+            idToEntry.put(id, entry);
             return true;
         }
         return false;
@@ -43,11 +45,6 @@ public class ClientNoxesiumRegistry<T> extends NoxesiumRegistry<T> {
 
     @Override
     public void remove(Key key) {
-        var value = keyToValue.get(key);
-        if (value == null) return;
         super.remove(key);
-
-        var id = valueToId.remove(value);
-        idToValue.remove(id);
     }
 }

--- a/api/src/main/java/com/noxcrew/noxesium/api/registry/NoxesiumRegistry.java
+++ b/api/src/main/java/com/noxcrew/noxesium/api/registry/NoxesiumRegistry.java
@@ -1,8 +1,10 @@
 package com.noxcrew.noxesium.api.registry;
 
 import com.noxcrew.noxesium.api.NoxesiumEntrypoint;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import net.kyori.adventure.key.Key;
 import org.jetbrains.annotations.Nullable;
@@ -13,11 +15,37 @@ import org.jetbrains.annotations.Nullable;
  * maps to a generic typed value.
  */
 public class NoxesiumRegistry<T> {
+    public static class Entry<T> {
+        private final Key key;
+        private final T value;
+        private int id = -1;
+
+        public Entry(Key key, T value) {
+            this.key = key;
+            this.value = value;
+        }
+
+        public Key key() {
+            return key;
+        }
+
+        public T value() {
+            return value;
+        }
+
+        public int id() {
+            return id;
+        }
+
+        public void setId(int id) {
+            this.id = id;
+        }
+    }
+
     private final Key id;
-    protected final Map<Integer, T> idToValue = new HashMap<>();
-    protected final Map<T, Integer> valueToId = new HashMap<>();
-    protected final Map<Key, T> keyToValue = new HashMap<>();
-    protected final Map<T, Key> valueToKey = new HashMap<>();
+    protected final Map<Integer, Entry<T>> idToEntry = new HashMap<>();
+    protected final Map<Key, Entry<T>> keyToEntry = new HashMap<>();
+    protected final Map<T, List<Entry<T>>> valueToEntries = new HashMap<>();
 
     public NoxesiumRegistry(Key id) {
         this.id = id;
@@ -34,45 +62,44 @@ public class NoxesiumRegistry<T> {
      * Fully clears and resets this registry.
      */
     public void reset() {
-        idToValue.clear();
-        valueToId.clear();
-        keyToValue.clear();
-        valueToKey.clear();
+        idToEntry.clear();
+        keyToEntry.clear();
+        valueToEntries.clear();
     }
 
     /**
      * Returns the keys of this registry.
      */
     public Collection<Key> getKeys() {
-        return keyToValue.keySet();
+        return keyToEntry.keySet();
     }
 
     /**
      * Returns all contents of this registry.
      */
     public Collection<T> getContents() {
-        return valueToKey.keySet();
+        return valueToEntries.keySet();
     }
 
     /**
      * Returns whether this registry contains the given key.
      */
     public boolean contains(Key key) {
-        return keyToValue.containsKey(key);
+        return keyToEntry.containsKey(key);
     }
 
     /**
      * Returns the size of this registry.
      */
     public int size() {
-        return keyToValue.size();
+        return keyToEntry.size();
     }
 
     /**
      * Returns whether the registry is empty.
      */
     public boolean isEmpty() {
-        return keyToValue.isEmpty();
+        return keyToEntry.isEmpty();
     }
 
     /**
@@ -86,12 +113,15 @@ public class NoxesiumRegistry<T> {
      * Registers a new entry into this registry.
      */
     public <V extends T> V register(Key key, V value, @Nullable NoxesiumEntrypoint entrypoint) {
-        if (keyToValue.get(key) != value) {
-            var oldValue = keyToValue.put(key, value);
-            if (oldValue != null) {
-                valueToKey.remove(oldValue);
-            }
-            valueToKey.put(value, key);
+        var entry = keyToEntry.get(key);
+        if (entry != null && entry.value() != value) {
+            remove(key);
+            entry = null;
+        }
+        if (entry == null) {
+            entry = new Entry<>(key, value);
+            keyToEntry.put(key, entry);
+            valueToEntries.computeIfAbsent(value, k -> new ArrayList<>()).add(entry);
         }
         return value;
     }
@@ -100,9 +130,14 @@ public class NoxesiumRegistry<T> {
      * Removes the given key from the registry.
      */
     public void remove(Key key) {
-        var oldValue = keyToValue.remove(key);
-        if (oldValue != null) {
-            valueToKey.remove(oldValue);
+        var entry = keyToEntry.remove(key);
+        if (entry != null) {
+            if (entry.id() != -1) idToEntry.remove(entry.id());
+            var list = valueToEntries.get(entry.value());
+            if (list != null) {
+                list.remove(entry);
+                if (list.isEmpty()) valueToEntries.remove(entry.value());
+            }
         }
     }
 
@@ -111,7 +146,8 @@ public class NoxesiumRegistry<T> {
      */
     @Nullable
     public T getById(int id) {
-        return idToValue.get(id);
+        var entry = idToEntry.get(id);
+        return entry == null ? null : entry.value();
     }
 
     /**
@@ -120,8 +156,8 @@ public class NoxesiumRegistry<T> {
      */
     public int getIdFor(T value) {
         if (value == null) return -1;
-        var boxed = valueToId.get(value);
-        return boxed == null ? -1 : boxed;
+        var list = valueToEntries.get(value);
+        return list == null || list.isEmpty() ? -1 : list.get(0).id();
     }
 
     /**
@@ -130,17 +166,17 @@ public class NoxesiumRegistry<T> {
      */
     public int getIdForKey(Key key) {
         if (key == null) return -1;
-        var value = getByKey(key);
-        if (value == null) return -1;
-        return getIdFor(value);
+        var entry = keyToEntry.get(key);
+        return entry == null ? -1 : entry.id();
     }
 
     /**
-     * Returns the key associated with the given value.
+     * Returns the key associated with the given id.
      */
     @Nullable
-    public Key getKeyFor(T value) {
-        return valueToKey.get(value);
+    public Key getKeyForId(int id) {
+        var entry = idToEntry.get(id);
+        return entry == null ? null : entry.key();
     }
 
     /**
@@ -148,6 +184,7 @@ public class NoxesiumRegistry<T> {
      */
     @Nullable
     public T getByKey(Key key) {
-        return keyToValue.get(key);
+        var entry = keyToEntry.get(key);
+        return entry == null ? null : entry.value();
     }
 }

--- a/api/src/main/java/com/noxcrew/noxesium/api/registry/ServerNoxesiumRegistry.java
+++ b/api/src/main/java/com/noxcrew/noxesium/api/registry/ServerNoxesiumRegistry.java
@@ -43,24 +43,23 @@ public class ServerNoxesiumRegistry<T> extends NoxesiumRegistry<T> {
     public <V extends T> V register(Key key, V value, @Nullable NoxesiumEntrypoint entrypoint) {
         super.register(key, value, entrypoint);
 
-        // Don't re-register if the value is already included!
-        if (valueToId.containsKey(value)) return value;
+        var entry = keyToEntry.get(key);
+        // Don't re-register if the key already has an ID!
+        if (entry.id() != -1) {
+            entrypoints.put(key, entrypoint == null ? null : entrypoint.getId());
+            return value;
+        }
 
         var id = lastId.getAndIncrement();
-        idToValue.put(id, value);
-        valueToId.put(value, id);
+        entry.setId(id);
+        idToEntry.put(id, entry);
         entrypoints.put(key, entrypoint == null ? null : entrypoint.getId());
         return value;
     }
 
     @Override
     public void remove(Key key) {
-        var value = keyToValue.get(key);
-        if (value == null) return;
         super.remove(key);
         entrypoints.remove(key);
-
-        var id = valueToId.remove(value);
-        idToValue.remove(id);
     }
 }

--- a/api/src/main/java/com/noxcrew/noxesium/api/registry/SynchronizedServerNoxesiumRegistry.java
+++ b/api/src/main/java/com/noxcrew/noxesium/api/registry/SynchronizedServerNoxesiumRegistry.java
@@ -44,7 +44,7 @@ public class SynchronizedServerNoxesiumRegistry<T> extends ServerNoxesiumRegistr
 
             // Determine the id of this key
             var value = getByKey(entry.getKey());
-            var index = getIdFor(value);
+            var index = getIdForKey(entry.getKey());
             data.put(entry.getKey(), Optional.ofNullable(value));
             keys.put(entry.getKey(), index);
         }
@@ -69,7 +69,7 @@ public class SynchronizedServerNoxesiumRegistry<T> extends ServerNoxesiumRegistr
             } else {
                 var value = getByKey(dirtyKey);
                 data.put(dirtyKey, Optional.ofNullable(value));
-                keys.put(dirtyKey, getIdFor(value));
+                keys.put(dirtyKey, getIdForKey(dirtyKey));
             }
         }
         return new NoxesiumRegistryPatch(id(), data, keys);
@@ -101,7 +101,7 @@ public class SynchronizedServerNoxesiumRegistry<T> extends ServerNoxesiumRegistr
     public void remove(Key key) {
         if (contains(key)) {
             pendingUpdates.add(key);
-            pendingRemovals.put(key, getIdFor(getByKey(key)));
+            pendingRemovals.put(key, getIdForKey(key));
             super.remove(key);
         }
     }

--- a/nms/src/main/java/com/noxcrew/noxesium/api/nms/codec/NoxesiumStreamCodecs.java
+++ b/nms/src/main/java/com/noxcrew/noxesium/api/nms/codec/NoxesiumStreamCodecs.java
@@ -176,8 +176,7 @@ public class NoxesiumStreamCodecs {
                 var id = buffer.readVarInt();
                 if (id == -1) return null;
 
-                var value = registry.getById(id);
-                return registry.getKeyFor(value);
+                return registry.getKeyForId(id);
             }
 
             @Override


### PR DESCRIPTION
## Issue
Current bidirectional map design in `NoxesiumRegistry` doesn't allow multiple keys to have the same value (e.g. QibDefinition), but on server side, registering same value to different keys is not prevented. This can cause several problems:
- In version 3.0.0: It caused an error on the client side when `ClientboundRegistryIdsUpdatePacket` is received. Consequently, the client would not respond a `ServerboundRegistryUpdateResultPacket`. Then the server would be stuck waiting and would not send that client any packets for future updates.
- In version 3.1.0: The exceptions were suppressed because BiMap was removed. Also, current maps can correctly store all keys despite equal values. However, `getKeyFor` will always return one of the keys among equal values. It works because the values are the same, meaning the effects are the same, but that's just not the right key and id.

## Change
- Introduced `NoxesiumRegistry.Entry<T>` wrapper class to encapsulate the id, key, and value bindings securely.